### PR TITLE
Never flush without items

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -84,7 +84,7 @@ func (b *Batcher[T]) start(ctx context.Context,
 
 		// If the batcher is cancelled and the buffer is not empty, we want to flush the
 		// remaining items with the maximum batch size, so we skip until we reach max size or the buffer is empty.
-		skipFlush := isCancelled && len(b.buffer) > 0 && !isMaxSize
+		skipFlush := (isCancelled && len(b.buffer) > 0 && !isMaxSize) || len(items) == 0
 
 		if !skipFlush {
 			// We need to copy the slice to make sure that the slice that is passed is valid even if asynchronously

--- a/batcher_test.go
+++ b/batcher_test.go
@@ -282,4 +282,17 @@ func TestBatcherCancellation(t *testing.T) {
 		assert.ErrorIs(t, batcher.Push(0), ErrBatcherStopped)
 		assert.Equal(t, 0, batcher.CurrentBufferSize())
 	})
+
+	t.Run("no empty flush after cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		_, flusher := startWithMockFlusher(ctx, t, New[int]())
+
+		cancel()
+
+		time.Sleep(time.Millisecond * 5)
+
+		assert.Equal(t, 0, flusher.StartCount())
+	})
 }


### PR DESCRIPTION
In a shutdown situation it was possible flush was called with an empty `items` slice - this prevents that and adds a test case for it.

This would happen when:
* The context has been cancelled
* The buffer is empty
* The current `items` array is empty.

`skipFlush` would be false:
```
isCancelled && len(b.buffer) > 0 && !maxSize
```
the `len(b.buffer) > 0` would be false, but there was no check whether there are any entries to be flushed.

